### PR TITLE
Improve sxhkd-config-reload keybinding

### DIFF
--- a/sxhkdrc.default
+++ b/sxhkdrc.default
@@ -18,9 +18,9 @@ super + alt + {Left,Down,Up,Right}
 super + Tab
         focuswrap next
 
-# kill sxhkd (for config changes, must be manually reopened)
-super + Escape
-        killall sxhkd
+# reload sxhkd configuration file
+super + r
+        killall -s SIGUSR1 sxhkd
 
 # toggle groups
 super + {1,2,3,4,5}


### PR DESCRIPTION
Normally you would not kill sxhkd during an X-session. The only reason I can see would be to reload the sxhkdrc, but there is a better way for that: Send it a SIGUSR1-signal and it will reload the rc without having to kill it (see the sxhkd-man page). I chose the keybinding `super + r` for **r**eload since Escape is often more associated with quitting or killing a process.

Now that killing sxhkd is not necessary anymore to reload its rc, it might be worth to consider using sxhkd as the process to spawn X in xinitrc.default and just removing xwait.