### PR TITLE
Remove unnecessary variables, pfw and pfd calls

### DIFF
--- a/disp
+++ b/disp
@@ -14,10 +14,11 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 . $XDG_CONFIG_HOME/wmrc/config
 . $XDG_CONFIG_HOME/wmrc/globals
 
-SW=$(dattr -w $(pfd) &)
-BSH=$(dattr -h $(pfd) &)
-SX=$(dattr -x $(pfd) &)
-SY=$(dattr -y $(pfd) &)
+CURDISP=$(pfd)
+SW=$(dattr -w $CURDISP &)
+BSH=$(dattr -h $CURDISP &)
+SX=$(dattr -x $CURDISP &)
+SY=$(dattr -y $CURDISP &)
 SH=$((BSH - PANEL))
 HSW=$((SW/2 - 2*BWIDTH - GAP - GAP/2))
 HSH=$((SH/2 - 2*BWIDTH - GAP - GAP/2))

--- a/focuswrap
+++ b/focuswrap
@@ -22,7 +22,7 @@ esac
 
 [ -z "$wid" ] && { echo "$(basename $0): no window to focus" >&2; exit 1; }
 
-if [ "$wid" = $(pfw) ]; then
+if [ "$wid" = $CUR ]; then
   exit 1
 fi
 

--- a/fullw
+++ b/fullw
@@ -17,7 +17,7 @@ usage() {
 
 full() {
   local MONITOR=${1:-$(pfd)}
-  local WINDOW=${2:-$(pfw)}
+  local WINDOW=${2:-$CUR}
   wattr xywhi $WINDOW > $FSFILE
   wtp $(dattr $MONITOR) $WINDOW
   focuswrap $WINDOW
@@ -27,7 +27,7 @@ full() {
 unfull() {
   wtp $(cat $FSFILE)
   rm -f $FSFILE
-  setborder active $(pfw)
+  setborder active $CUR
 }
 
 [ -z "$1" ] && [ -z "$2" ] && usage

--- a/fullw
+++ b/fullw
@@ -16,7 +16,7 @@ usage() {
 }
 
 full() {
-  local MONITOR=${1:-$(pfd)}
+  local MONITOR=${1:-$CURDISP}
   local WINDOW=${2:-$CUR}
   wattr xywhi $WINDOW > $FSFILE
   wtp $(dattr $MONITOR) $WINDOW

--- a/globals
+++ b/globals
@@ -4,10 +4,8 @@
 # (c) ix 2016
 #
 
-WID=$(pfw)
-WW=$(wattr w $WID)
-WH=$(wattr h $WID)
-CUR=${2:-$(pfw)}
+CUR=$(pfw)
+WW=$(wattr w $CUR)
+WH=$(wattr h $CUR)
 ROOT=$(lsw -r)
 BWIDTH=$(wattr b $CUR)
-PFW=$(pfw)

--- a/groupmgr
+++ b/groupmgr
@@ -16,6 +16,7 @@ GRPNUM=5
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 
 . $XDG_CONFIG_HOME/wmrc/config
+. $XDG_CONFIG_HOME/wmrc/globals
 
 usage() {
   echo "$(basename $0) [-adsth <gid>]"
@@ -93,9 +94,9 @@ cgrps
 
 while getopts ":a:d:gs:t:h:" opt; do
   case $opt in
-    a) addtgrp $(pfw) $OPTARG ;;
-    d) removefgrp $(pfw) $OPTARG ;;
-    g) findgrp $(pfw) ;;
+    a) addtgrp $CUR $OPTARG ;;
+    d) removefgrp $CUR $OPTARG ;;
+    g) findgrp $CUR ;;
     s) showgrp $OPTARG ;;
     t) togggrp $OPTARG ;;
     h) hidegrp $OPTARG ;;

--- a/killwin
+++ b/killwin
@@ -4,14 +4,17 @@
 # (c) ix && wildefyr 2016
 #
 
-wid=$(pfw)
-windowc=$(winclass -c $wid)
-windowm=$(winclass -m $wid)
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+. $XDG_CONFIG_HOME/wmrc/globals
+
+windowc=$(winclass -c $CUR)
+windowm=$(winclass -m $CUR)
 
 if [ "$windowm" = "Firefox" ]; then
-  killwa $wid
+  killwa $CUR
 elif [ "$windowc" = "urxvt" ]; then
-  killwa $wid
+  killwa $CUR
 else
-  killw $wid
+  killw $CUR
 fi

--- a/pulsew
+++ b/pulsew
@@ -7,11 +7,12 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 . $XDG_CONFIG_HOME/wmrc/config
+. $XDG_CONFIG_HOME/wmrc/globals
 
 while :; do
   cols=$(tac < $PULSECOLS | cat - $PULSECOLS | tr -d '#')
   for col in $cols; do
-    test "`wattr wh $PFW`" != "`wattr wh $(lsw -r)`" && chwb -c $col $PFW
+    test "`wattr wh $CUR`" != "`wattr wh $(lsw -r)`" && chwb -c $col $CUR
     sleep $FREQ
   done
 done

--- a/setborder
+++ b/setborder
@@ -7,6 +7,7 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 
 . $XDG_CONFIG_HOME/wmrc/config
+. $XDG_CONFIG_HOME/wmrc/globals
 
 wattr $2 || return
 wattr o $2 && return
@@ -14,7 +15,7 @@ wattr o $2 && return
 [ "$(wattr xywh $2)" = "$(wattr xywh $ROOT)" ] && return
 if [ -f $FSFILE ] \
   && [ "$(cat $FSFILE | awk '{print $5}')" = "$2" ] \
-  && [ "$(wattr x $(pfw))" = "$(cat $FSFILE | awk '{print $1}')" ]; then
+  && [ "$(wattr x $CUR)" = "$(cat $FSFILE | awk '{print $1}')" ]; then
   exit 1
 fi
 

--- a/snapw
+++ b/snapw
@@ -19,38 +19,38 @@ case $2 in
 esac
 
 right() {
-  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + GAP + PANEL)) $((SW/2 - 2*BWIDTH - GAP - GAP/2)) $((SH - 2*BWIDTH - 2*GAP)) $PFW
+  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + GAP + PANEL)) $((SW/2 - 2*BWIDTH - GAP - GAP/2)) $((SH - 2*BWIDTH - 2*GAP)) $CUR
 }
 
 left() {
-  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $((SW/2 - 2*BWIDTH - GAP - GAP/2)) $((SH - 2*BWIDTH - 2*GAP)) $PFW
+  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $((SW/2 - 2*BWIDTH - GAP - GAP/2)) $((SH - 2*BWIDTH - 2*GAP)) $CUR
 }
 
 down() {
   up
-  #wtp $((SX + GAP)) $((SY + SH - SH/2)) $((SW - 2*GAP - 2*BWIDTH)) $((SH/2 - 2*BWIDTH - GAP - GAP/2)) $PFW
-  wmv 0 $((SH/2 - BWIDTH - GAP/2)) $PFW
+  #wtp $((SX + GAP)) $((SY + SH - SH/2)) $((SW - 2*GAP - 2*BWIDTH)) $((SH/2 - 2*BWIDTH - GAP - GAP/2)) $CUR
+  wmv 0 $((SH/2 - BWIDTH - GAP/2)) $CUR
 }
 
 up() {
-  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $((SW - 2*GAP - 2*BWIDTH)) $((SH/2 - 2*BWIDTH - GAP - GAP/2)) $PFW
+  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $((SW - 2*GAP - 2*BWIDTH)) $((SH/2 - 2*BWIDTH - GAP - GAP/2)) $CUR
 }
 
 topright() {
-  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + GAP + PANEL)) $HSW $HSH $PFW
+  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + GAP + PANEL)) $HSW $HSH $CUR
 }
 
 topleft() {
-  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $HSW $HSH $PFW
+  wtp $((SX + GAP)) $((SY + GAP + PANEL)) $HSW $HSH $CUR
 }
 
 bottomright() {
-  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + SH - SH/2 + GAP/2 + PANEL)) $HSW $HSH $PFW
+  wtp $((SX + SW - SW/2 + GAP/2)) $((SY + SH - SH/2 + GAP/2 + PANEL)) $HSW $HSH $CUR
 }
 
 
 bottomleft() {
-  wtp $((SX + GAP)) $((SY + SH - SH/2 + GAP/2 + PANEL)) $HSW $HSH $PFW
+  wtp $((SX + GAP)) $((SY + SH - SH/2 + GAP/2 + PANEL)) $HSW $HSH $CUR
 }
 
 case $1 in


### PR DESCRIPTION
Hello ix, this time the pull request is a bit longer. I quite like the idea of wmrc, so you might see a couple of pull requests or issues from me in the future.

Most of this pull request is straightforward and should improve performance a little. It also fixes bugs in pulsew and snapw (see first commit message). 

In setborder, killwin and groupmgr I introduced a sourcing of globals although there is only one call of pfw each, which might make the performance a little worse. I did it for consistency's sake and in case future changes introduce more global variables in those files. However, I can rebase if you think a single pfw call is better in those cases.