### PR TITLE
Multiple panel support and clearer naming/use of disp variables

### DIFF
--- a/config.default
+++ b/config.default
@@ -24,6 +24,8 @@ INACTIVE=${INACTIVE:-0x3c3732} ## border color of inactive window
 FREQ=0.08                      ## frequency to pulse borders
 
 # snapping
-
-PANEL=50 ## height of the top panel
-GAP=20   ## gaps between windows
+TPANEL=50 ## height of the top panel
+BPANEL=0  ## height of the bottom panel
+LPANEL=0  ## width of the left panel
+RPANEL=0  ## width of the right panel
+GAP=20    ## gaps between windows

--- a/cornerw
+++ b/cornerw
@@ -6,7 +6,6 @@
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 
-. $XDG_CONFIG_HOME/wmrc/config
 . $XDG_CONFIG_HOME/wmrc/globals
 . $XDG_CONFIG_HOME/wmrc/disp
 
@@ -14,16 +13,15 @@ X=$SX
 Y=$SY
 
 case $1 in
-  tl) X=$SX ;;
   tr) X=$((SW + SX - WW - BWIDTH*2)) ;;
-  bl) Y=$((BSH + SY - WH - BWIDTH*2)) ;;
+  bl) Y=$((SH + SY - WH - BWIDTH*2)) ;;
   br)
     X=$((SW + SX - WW - BWIDTH*2))
-    Y=$((BSH + SY - WH - BWIDTH*2))
+    Y=$((SH + SY - WH - BWIDTH*2))
     ;;
   md)
     X=$((SW/2 + SX - WW/2 - BWIDTH))
-    Y=$((BSH/2 + SY - WH/2 - BWIDTH))
+    Y=$((SH/2 + SY - WH/2 - BWIDTH))
     ;;
 esac
 

--- a/disp
+++ b/disp
@@ -12,11 +12,18 @@
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 . $XDG_CONFIG_HOME/wmrc/config
-. $XDG_CONFIG_HOME/wmrc/globals
 
+# variables for window positioning with panels but ignoring gaps
 CURDISP=$(pfd)
 SW=$(dattr -w $CURDISP &)
 BSH=$(dattr -h $CURDISP &)
 SX=$(dattr -x $CURDISP &)
 SY=$(dattr -y $CURDISP &)
 SH=$((BSH - PANEL))
+
+# variables for window positioning with outer gaps and panels
+# (borders are not substracted here!)
+LEFT=$((SX + GAP))
+TOP=$((SY + GAP + PANEL))
+WHOLEW=$((SW - 2*GAP))
+WHOLEH=$((SH - 2*GAP))

--- a/disp
+++ b/disp
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # wmrc display variables
-# (c) ix 2016
+# (c) ix & milsen 2016
 #
 
 # these are seperate from the rest of the
@@ -13,17 +13,22 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 . $XDG_CONFIG_HOME/wmrc/config
 
-# variables for window positioning with panels but ignoring gaps
+# total screen dimensions
 CURDISP=$(pfd)
-SW=$(dattr -w $CURDISP &)
-BSH=$(dattr -h $CURDISP &)
-SX=$(dattr -x $CURDISP &)
-SY=$(dattr -y $CURDISP &)
-SH=$((BSH - PANEL))
+TOTALSW=$(dattr -w $CURDISP &)
+TOTALSH=$(dattr -h $CURDISP &)
+TOTALSX=$(dattr -x $CURDISP &)
+TOTALSY=$(dattr -y $CURDISP &)
 
-# variables for window positioning with outer gaps and panels
+# variables for window positioning with panels but ignoring outer gaps
+SW=$((TOTALSW - LPANEL - RPANEL))
+SH=$((TOTALSH - TPANEL - BPANEL))
+SX=$((TOTALSX + LPANEL))
+SY=$((TOTALSY + TPANEL))
+
+# variables for window positioning with panels and outer gaps
 # (borders are not substracted here!)
 LEFT=$((SX + GAP))
-TOP=$((SY + GAP + PANEL))
+TOP=$((SY + GAP))
 WHOLEW=$((SW - 2*GAP))
 WHOLEH=$((SH - 2*GAP))

--- a/expandw
+++ b/expandw
@@ -21,8 +21,6 @@ done
 
 shift $((OPTIND - 1))
 
-MONITOR=$(pfd)
-
 usage() {
   echo "usage: $(basename $0) [-hv] <wid>" >&2
   exit ${1:-0}
@@ -33,7 +31,7 @@ usage() {
 expand() {
   wattr xywhi $CUR > $EXPANDDIR/$CUR
   case $DIRECTION in
-    vert) GEO=$(printf '%d 0 %d %d' $(wattr xw $CUR) $((BSH - 2*BWIDTH))) ;;
+    vert) GEO=$(printf "%d $SY %d %d" $(wattr xw $CUR) $((SH - 2*BWIDTH))) ;;
     horiz) GEO=$(printf "$SX %d %d %d" $(wattr y $CUR) $((SW - 2*BWIDTH)) $(wattr h $CUR)) ;;
   esac
   wtp $GEO $CUR
@@ -47,7 +45,7 @@ collapse() {
 
 checkmax() {
   case $DIRECTION in
-    vert) [ $(wattr h $CUR) -eq $((BSH - 2*BWIDTH)) ] && return 0 ;;
+    vert) [ $(wattr h $CUR) -eq $((SH - 2*BWIDTH)) ] && return 0 ;;
     horiz) [ $(wattr w $CUR) -eq $((SW - 2*BWIDTH)) ] && return 0 ;;
   esac
 }

--- a/snapw
+++ b/snapw
@@ -22,11 +22,11 @@ esac
 LEFT=$((SX + GAP))
 RIGHT=$((SX + SW - SW/2 + GAP/2))
 TOP=$((SY + GAP + PANEL))
-BOTTOM=$((SY + SH - SH/2))
+BOTTOM=$((PANEL + SY + SH - SH/2))
 
 HALFW=$((SW/2 - 2*BWIDTH - GAP - GAP/2))
 WHOLEW=$((SW - 2*GAP - 2*BWIDTH))
-HALFH=$((PANEL + SH/2 - 2*BWIDTH - GAP - GAP/2))
+HALFH=$((SH/2 - 2*BWIDTH - GAP - GAP/2))
 WHOLEH=$((SH - 2*GAP - 2*BWIDTH))
 
 case $1 in

--- a/snapw
+++ b/snapw
@@ -6,7 +6,6 @@
 
 XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
-. $XDG_CONFIG_HOME/wmrc/config
 . $XDG_CONFIG_HOME/wmrc/globals
 . $XDG_CONFIG_HOME/wmrc/disp
 
@@ -18,16 +17,15 @@ case $2 in
   0x*) CUR=$2 ;;
 esac
 
-# define variables for screen positioning
-LEFT=$((SX + GAP))
-RIGHT=$((SX + SW - SW/2 + GAP/2))
-TOP=$((SY + GAP + PANEL))
-BOTTOM=$((PANEL + SY + SH - SH/2))
+# define variables for window positioning
+HALFW=$(((WHOLEW - GAP - 4*BWIDTH) / 2))
+HALFH=$(((WHOLEH - GAP - 4*BWIDTH) / 2))
 
-HALFW=$((SW/2 - 2*BWIDTH - GAP - GAP/2))
-WHOLEW=$((SW - 2*GAP - 2*BWIDTH))
-HALFH=$((SH/2 - 2*BWIDTH - GAP - GAP/2))
-WHOLEH=$((SH - 2*GAP - 2*BWIDTH))
+RIGHT=$((LEFT + HALFW + 2*BWIDTH + GAP))
+BOTTOM=$((TOP + HALFH + 2*BWIDTH + GAP))
+
+WHOLEW=$((WHOLEW - 2*BWIDTH))
+WHOLEH=$((WHOLEH - 2*BWIDTH))
 
 case $1 in
   left|l)          wtp $LEFT  $TOP    $HALFW  $WHOLEH $CUR ;;

--- a/tilew
+++ b/tilew
@@ -15,11 +15,6 @@ usage() {
   echo "usage: $(basename $0) [-w master-width] [wid]"
 }
 
-# calculate usable screen size without outer gaps
-# (panel is already substracted in disp)
-SW=$((SW - 2*GAP))
-SH=$((SH - 2*GAP))
-
 # get master-area width, use half the screen as default
 while getopts ":w:" opt; do
   case $opt in
@@ -29,15 +24,14 @@ while getopts ":w:" opt; do
 done
 shift $((OPTIND - 1))
 
-HALF=$(((SW - GAP)/2))
+HALF=$(((WHOLEW - GAP)/2))
 MASTER=${MASTER:-$HALF}
 
 # if no wid given, use wid of current window
 CUR=${1:-$CUR}
 
 # put current window in master area
-Y=$((GAP + PANEL))
-wtp $GAP $Y $((MASTER - 2*BWIDTH)) $((SH - 2*BWIDTH)) $CUR
+wtp $LEFT $TOP $((MASTER - 2*BWIDTH)) $((WHOLEH - 2*BWIDTH)) $CUR
 
 # get the number of windows to put in the stacking area
 STWINNR=$(lsw | grep -v $CUR | wc -l)
@@ -45,22 +39,23 @@ STWINNR=$(lsw | grep -v $CUR | wc -l)
 # stack up all remaining windows on the right if there are any
 if [ ! $STWINNR -eq 0 ]; then
 
-  # calculate x-position and width of stacked windows
+  # calculate x/y-position and width of stacked windows
   X=$((MASTER + 2*GAP))
-  W=$((SW - MASTER - GAP - 2*BWIDTH))
+  Y=$TOP
+  W=$((WHOLEW - MASTER - GAP - 2*BWIDTH))
 
-  # substract gaps between stacked windows from usable height SH
+  # substract gaps between stacked windows from usable height WHOLEH
   # as well as borders for each window
-  SH=$((SH - (STWINNR - 1)*GAP - STWINNR*2*BWIDTH))
+  WHOLEH=$((WHOLEH - (STWINNR - 1)*GAP - STWINNR*2*BWIDTH))
 
   # calculate height of each stacked window and rest pixels
-  BASEH=$((SH/STWINNR))
-  RESTPXS=$((SH%STWINNR))
+  BASEH=$((WHOLEH/STWINNR))
+  RESTPXS=$((WHOLEH%STWINNR))
 
   # stack all non-current windows on the right
   for wid in $(lsw | grep -v $CUR); do
     # if the height of the stacking area cannot be cleanly divided by the number
-    # of windows, add one pixel to each of the first SH%STWINNR windows in the
+    # of windows, add one pixel to each of the first WHOLEH%STWINNR windows in the
     # stacking area
     if [ $RESTPXS -gt 0 ]; then
       H=$((BASEH + 1))


### PR DESCRIPTION
A new day, a new pull request.

Features: 
- clear setup of variables in disp (look at the comments in disp, you'll understand)
- multiple panel support

Important:
- The config variable PANEL changed its name to TPANEL.
- LPANEL, RPANEL and BPANEL also exist now in the config.
- Some disp variables changed their name, and I changed the variables in cornerw and expandw accordingly. However, I was not sure whether the scripts should respect panels or not. I made them respect panels as I like that behavior more. But if you like window expansion/cornering going on top of panels, we could implement an option that does that.